### PR TITLE
chore: add GitHub Actions workflow to build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: ci
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: install elixir and erlang
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+
+      - name: install hex and rebar3
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+
+      - name: install dependencies
+        run: |
+          mix deps.get
+
+      - name: compile code
+        run: |
+          mix compile
+
+      - name: run unit tests
+        run: |
+          mix test
+
+      # package, tag, push to hex?
+
+  version-builds:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - elixir-version: "1.9.4-otp-22"
+            otp-version: "22.3.4.26"
+          - elixir-version: "1.10.4-otp-22"
+            otp-version: "22.3.4.26"
+          - elixir-version: "1.10.4-otp-23"
+            otp-version: "23.3.4.18"
+          - elixir-version: "1.11.4-otp-22"
+            otp-version: "22.3.4.26"
+          - elixir-version: "1.11.4-otp-23"
+            otp-version: "23.3.4.18"
+          - elixir-version: "1.11.4-otp-24"
+            otp-version: "24.3.4.11"
+          - elixir-version: "1.12.3-otp-22"
+            otp-version: "22.3.4.26"
+          - elixir-version: "1.12.3-otp-23"
+            otp-version: "23.3.4.18"
+          - elixir-version: "1.12.3-otp-24"
+            otp-version: "24.3.4.11"
+          - elixir-version: "1.13.4-otp-22"
+            otp-version: "22.3.4.26"
+          - elixir-version: "1.13.4-otp-23"
+            otp-version: "23.3.4.18"
+          - elixir-version: "1.13.4-otp-24"
+            otp-version: "24.3.4.11"
+          - elixir-version: "1.13.4-otp-25"
+            otp-version: "25.3.2"
+          - elixir-version: "1.14.4-otp-23"
+            otp-version: "23.3.4.18"
+          - elixir-version: "1.14.4-otp-24"
+            otp-version: "24.3.4.11"
+    steps:
+      - name: check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: install elixir and erlang
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ matrix.elixir-version }}
+          otp-version: ${{ matrix.otp-version }}
+          version-type: strict
+
+      - name: install hex and rebar3
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+
+      - name: install dependencies
+        run: |
+          mix deps.get
+
+      - name: compile code
+        run: |
+          mix compile
+
+      - name: run unit tests
+        run: |
+          mix test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 25.3.2
+elixir 1.14.5-otp-25


### PR DESCRIPTION
I can’t really test this in space_ex until it’s merged to master (GitHub Actions doesn’t know it exists until then), but after that it will work from branches.

Nothing permanent like creating releases happens in this workflow (at least not yet), so there’s no harm if it starts running after merge. If you’d like to play it safe, the pull_request handler (lines 3-4 of ci.yml) can be commented out, and then the workflow will run only when manually dispatched.